### PR TITLE
doc: fix broken link to `Boostv1.66.0` download page ( #26 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prerequisite:
   apt-get install -y git cmake wget unzip
 * Install ```boost```.
   ```
-  wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.bz2
+  wget https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/boost_1_66_0_rc2.tar.bz2
   tar --bzip2 -xf  boost_1_66_0.tar.bz2
   cd boost_1_66_0
   ./bootstrap.sh --prefix=/usr/local


### PR DESCRIPTION
## Summary

Boost moved all downloads to `JFrog Artifactory` here:  https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html
